### PR TITLE
Fix to use abspath for config path

### DIFF
--- a/chatrex/upn/inference_wrapper.py
+++ b/chatrex/upn/inference_wrapper.py
@@ -17,7 +17,8 @@ def build_model(
     ckpt_path: str,
 ):
     current_path = os.path.dirname(os.path.abspath(__file__))
-    config_path = f"chatrex/upn/configs/upn_large.py"
+    config_file = f"configs/upn_large.py"
+    config_path = os.path.join(current_path, config_file)
     model_cfg = Config.fromfile(config_path).model
     model = build_architecture(model_cfg)
     checkpoint = torch.load(ckpt_path, map_location="cpu")


### PR DESCRIPTION

Fix config path to use abspath so that chatrex can be called from anywhere. 
Now, when I use chatrex from outside of this repository's root, I get following error;

```bash
loading upn model...
Traceback (most recent call last):
  File "/workspace/src/chatrex_image_grounded_caption.py", line 43, in <module>
    model_upn = UPNWrapper(ckpt_path)
  File "/ChatRex/chatrex/upn/inference_wrapper.py", line 37, in __init__
    self.model = build_model(ckpt_path)
  File "/ChatRex/chatrex/upn/inference_wrapper.py", line 21, in build_model
    model_cfg = Config.fromfile(config_path).model
  File "/opt/conda/lib/python3.10/site-packages/mmengine/config/config.py", line 448, in fromfile
    lazy_import is None and not Config._is_lazy_import(filename):
  File "/opt/conda/lib/python3.10/site-packages/mmengine/config/config.py", line 1612, in _is_lazy_import
    with open(filename, encoding='utf-8') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'chatrex/upn/configs/upn_large.py'
```